### PR TITLE
Updates cmake config and README for Linux installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if (NOT WIN32 OR MSYS OR CYGWIN)
 	set(CLANG_LIBS -lclangTooling -lclangFrontendTool -lclangFrontend -lclangDriver -lclangSerialization
 					-lclangCodeGen -lclangParse -lclangSema -lclangStaticAnalyzerFrontend -lclangStaticAnalyzerCheckers
 					-lclangStaticAnalyzerCore -lclangAnalysis -lclangARCMigrate -lclangRewriteFrontend -lclangRewrite
-					-lclangEdit -lclangAST -lclangASTMatchers -lclangLex -lclangBasic ${LLVM_LIBS} -lcurses)
+					-lclangEdit -lclangAST -lclangASTMatchers -lclangLex -lclangBasic ${LLVM_LIBS} -lcurses -lz -ldl -lpthread)
 
 else ()
 	#   set(LLVM_SRC "" CACHE PATH "LLVM source directory")

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ chauffeur
 
 Clang AST frontend for Linux device driver analysis
 
+##Prerequisites
+- llvm 3.5
+- cmake
+- libncurses5-dev (required apt package for Ubuntu 14.04 LTS)
+
 ##How to compile
 
-	cmake -D LLVM_CONFIG=${PATH_TO_LLVM}/build/bin -D CMAKE_BUILD_TYPE=Release ../src
+	cmake -D LLVM_CONFIG=${PATH_TO_LLVM}/build/bin -D CMAKE_BUILD_TYPE=Release .


### PR DESCRIPTION
On linux systems zlib, dl, and pthread must be added to the list of
libraries to be linked during build.

Adds some prerequisite information to README file.
